### PR TITLE
Ensuring negative values for offsets can be provided through the cli

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,11 +10,11 @@ pub struct Cli {
     pub index: u32,
 
     /// Core clock offset (MHz)
-    #[arg(short, long)]
+    #[arg(short, long, allow_hyphen_values(true))]
     pub core_clock_offset: Option<i32>,
 
     /// Memory clock offset (MHz)
-    #[arg(short, long)]
+    #[arg(short, long, allow_hyphen_values(true))]
     pub memory_clock_offset: Option<i32>,
 
     /// Power limit (W)


### PR DESCRIPTION
Without setting this option, providing a negative offset value results in an error of form 'error: Found argument '-1' which wasn't expected, or isn't valid in this context'. This effectively prevents the use of the cli for undervolting.